### PR TITLE
feat: configModuleOptions

### DIFF
--- a/spec/dotenv-source-provider/config.service.ts
+++ b/spec/dotenv-source-provider/config.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+import { Expose, Transform, Type } from 'class-transformer';
+import { IsNotEmpty, IsOptional, IsPositive, IsString } from 'class-validator';
+
+import { AbstractConfigService } from '../../src/lib/abstract/abstract-config.service';
+
+@Injectable()
+export class ConfigService extends AbstractConfigService<ConfigService> {
+    @Expose({ name: 'LISTENING_PORT' })
+    @Type(() => Number)
+    @IsPositive()
+    @IsNotEmpty()
+    port: number;
+
+    @Expose({ name: 'URL' })
+    @IsString()
+    @IsOptional()
+    url: string;
+
+    @Expose({ name: 'HOST' })
+    @Transform(({ value }) => value ?? 'default')
+    @IsString()
+    @IsOptional()
+    host: string;
+}

--- a/spec/dotenv-source-provider/dotenv-source-provider.spec.ts
+++ b/spec/dotenv-source-provider/dotenv-source-provider.spec.ts
@@ -1,17 +1,52 @@
 import path from 'path';
 
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { ConfigService } from './config.service';
+import { ConfigModule } from '../../src';
 import { DotenvSourceProvider } from '../../src/lib/provider/dotenv-source-provider';
 
-describe('dotenv provider의 동작을 검증합니다', () => {
-    it('파일이 없을때 error를 throw 하여야 합니다', () => {
-        expect(() => new DotenvSourceProvider({ path: './not-found-file.env' }).export()).toThrowError();
+describe('DotenvSourceProvider', () => {
+    let app: INestApplication;
+
+    beforeEach(async () => {
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [
+                ConfigModule.forFeature(ConfigService, {
+                    sourceProvider: new DotenvSourceProvider({ path: path.join(__dirname, 'test.env') }),
+                }),
+            ],
+        }).compile();
+
+        app = moduleFixture.createNestApplication();
+        await app.init();
     });
 
-    it('환경 변수 파일을 로드할 수 있습니다', () => {
-        const absPath = path.join(__dirname, 'test.env');
-        expect(new DotenvSourceProvider({ path: absPath }).export()).toEqual({
-            LISTENING_PORT: '9999',
-            REDIS_URL: 'hello',
+    afterEach(async () => {
+        await app?.close();
+    });
+
+    it('should configure ConfigService from env file', () => {
+        const service = app.get<ConfigService>(ConfigService);
+        expect(service).toEqual({
+            port: 9999,
+            url: 'hello',
+            host: 'default',
+        });
+    });
+
+    describe('features of DotenvSourceProvider', () => {
+        it('should load environment file', () => {
+            const absPath = path.join(__dirname, 'test.env');
+            expect(new DotenvSourceProvider({ path: absPath }).export()).toEqual({
+                LISTENING_PORT: '9999',
+                URL: 'hello',
+            });
+        });
+
+        it('should be through error, when file is not exist', () => {
+            expect(() => new DotenvSourceProvider({ path: './not-found-file.env' }).export()).toThrowError();
         });
     });
 });

--- a/spec/dotenv-source-provider/test.env
+++ b/spec/dotenv-source-provider/test.env
@@ -1,2 +1,2 @@
 LISTENING_PORT=9999
-REDIS_URL=hello
+URL=hello

--- a/spec/logging/hide-config.service.ts
+++ b/spec/logging/hide-config.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { Expose, Transform, Type } from 'class-transformer';
+import { IsNotEmpty, IsOptional, IsPositive, IsString } from 'class-validator';
+
+import { AbstractConfigService } from '../../src/lib/abstract/abstract-config.service';
+
+@Injectable()
+export class HideConfigService extends AbstractConfigService<HideConfigService> {
+    @Expose({ name: 'LISTENING_PORT' })
+    @Transform(({ value }) => value ?? 1234)
+    @Type(() => Number)
+    @IsPositive()
+    @IsNotEmpty()
+    hidePort: number;
+
+    @Expose({ name: 'URL' })
+    @Transform(({ value }) => value ?? 'default')
+    @IsString()
+    @IsOptional()
+    hideUrl: string;
+
+    @Expose({ name: 'HOST' })
+    @Transform(({ value }) => value ?? 'default')
+    @IsString()
+    @IsOptional()
+    hideHost: string;
+}

--- a/spec/logging/logging-config.service.ts
+++ b/spec/logging/logging-config.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { Expose, Transform, Type } from 'class-transformer';
+import { IsNotEmpty, IsOptional, IsPositive, IsString } from 'class-validator';
+
+import { AbstractConfigService } from '../../src/lib/abstract/abstract-config.service';
+
+@Injectable()
+export class LoggingConfigService extends AbstractConfigService<LoggingConfigService> {
+    @Expose({ name: 'LISTENING_PORT' })
+    @Transform(({ value }) => value ?? 1234)
+    @Type(() => Number)
+    @IsPositive()
+    @IsNotEmpty()
+    loggingPort: number;
+
+    @Expose({ name: 'URL' })
+    @Transform(({ value }) => value ?? 'default')
+    @IsString()
+    @IsOptional()
+    loggingUrl: string;
+
+    @Expose({ name: 'HOST' })
+    @Transform(({ value }) => value ?? 'default')
+    @IsString()
+    @IsOptional()
+    loggingHost: string;
+}

--- a/spec/logging/logging.spec.ts
+++ b/spec/logging/logging.spec.ts
@@ -1,0 +1,35 @@
+import { Logger } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+
+import { HideConfigService } from './hide-config.service';
+import { LoggingConfigService } from './logging-config.service';
+import { ConfigModule } from '../../src';
+
+describe('Logging Option', () => {
+    it('should be output debugging logs when logging is not false', async () => {
+        const logger = new Logger();
+        const loggerSpy: jest.SpyInstance = jest.spyOn(logger, 'log');
+        await Test.createTestingModule({
+            imports: [
+                ConfigModule.forFeature(LoggingConfigService),
+                ConfigModule.forFeature(HideConfigService, {
+                    logging: false,
+                }),
+            ],
+        })
+            .setLogger(logger)
+            .compile();
+
+        const logging = [
+            '[ConfigModule] Read Environment from LoggingConfigService',
+            '[LoggingConfigService] loggingPort: 1234',
+            '[LoggingConfigService] loggingUrl: default',
+            '[LoggingConfigService] loggingHost: default',
+        ];
+        expect(loggerSpy).toHaveBeenCalledTimes(logging.length);
+
+        for (const [index, message] of logging.entries()) {
+            expect(loggerSpy).toHaveBeenNthCalledWith(index + 1, message);
+        }
+    });
+});


### PR DESCRIPTION
> ⭐ 🌟 ⭐ This PR includes break change⭐ 🌟 ⭐ 

## Break change

- The `sourceProvider` interface has changed.

<hr/>

### ConfigModuleOptions

Defines the `option interface` for the ConfigModule. The Options is `optional`.

I hope this interface be used when ConfigModule`s features add.

- The `sourceProvider` interface has changed
```
# AS-IS
@Module({
    imports: [ConfigModule.forFeature(AppConfigService, new DotenvSourceProvider())]
...

# TO-BE
@Module({
    imports: [ConfigModule.forFeature(AppConfigService, { sourceProvider: new DotenvSourceProvider() })]
...
```

- Provides `logging` options
  - it can hide logging, if don`t want it.
  - default is `true`
```
@Module({
    imports: [ConfigModule.forFeature(AppConfigService, { logging: false })]
...
```
