### PR TITLE
feat: exclude source files in example directory from build

### DIFF
--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -4,5 +4,5 @@
         "rootDir": "src"
     },
     "include": ["src/**/*.ts"],
-    "exclude": ["**/*.spec.ts", "**/*.test.ts"]
+    "exclude": ["**/*.spec.ts", "**/*.test.ts", "src/example/**/*.ts"]
 }


### PR DESCRIPTION
## Background

With current `tsconfig.lib.json`, files in `example` directory is included when build.

## Goal

Since files in `example` directory is unnecessary for the packages, remove it from the build.