### PR TITLE
typescript is required package

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
         "lodash": "4.17.21",
         "reflect-metadata": "0.1.13",
         "rxjs": "7.8.0",
-        "tslib": "2.5.0"
+        "tslib": "2.5.0",
+        "typescript": "~4.9.4"
     },
     "devDependencies": {
         "@commitlint/config-conventional": "^17.4.4",
@@ -67,7 +68,6 @@
         "prettier": "^2.6.2",
         "release-it": "^15.10.0",
         "ts-jest": "28.0.8",
-        "ts-node": "10.9.1",
-        "typescript": "~4.9.4"
+        "ts-node": "10.9.1"
     }
 }


### PR DESCRIPTION
### typescript is required package

- Typescript package is required on ConfigScanner
- refer to [PR#5](https://github.com/woowabros/nestjs-library-config/pull/5)