### PR TITLE
test: add multiple config case

### DIFF
--- a/spec/config/log-level.enum.ts
+++ b/spec/config/log-level.enum.ts
@@ -1,0 +1,9 @@
+export enum LogLevel {
+    INFO = 'INFO',
+    DEBUG = 'DEBUG',
+    TRACE = 'TRACE',
+    WARN = 'WARN',
+    ERROR = 'ERROR',
+    FATAL = 'FATAL',
+    SILENT = 'SILENT',
+}

--- a/spec/config/logger-config.service.ts
+++ b/spec/config/logger-config.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { Expose, Transform, Type } from 'class-transformer';
+import { IsEnum } from 'class-validator';
+
+import { LogLevel } from './log-level.enum';
+import { AbstractConfigService } from '../../src';
+
+@Injectable()
+export class LoggerConfigService extends AbstractConfigService<LoggerConfigService> {
+    @Expose({ name: 'LOG_LEVEL' })
+    @Transform(({ value }) => value ?? LogLevel.INFO)
+    @Type(() => Number)
+    @IsEnum(LogLevel)
+    logLevel: LogLevel;
+}

--- a/spec/config/pino-config.service.ts
+++ b/spec/config/pino-config.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { Expose, Transform, Type } from 'class-transformer';
+import { IsEnum } from 'class-validator';
+
+import { LogLevel } from './log-level.enum';
+import { AbstractConfigService } from '../../src';
+
+@Injectable()
+export class PinoConfigService extends AbstractConfigService<PinoConfigService> {
+    @Expose({ name: 'LOG_LEVEL' })
+    @Transform(({ value }) => value ?? LogLevel.DEBUG)
+    @Type(() => Number)
+    @IsEnum(LogLevel)
+    logLevel: LogLevel;
+}

--- a/spec/multiple-config-as-array/app-config.service.spec.ts
+++ b/spec/multiple-config-as-array/app-config.service.spec.ts
@@ -3,23 +3,30 @@ import { Test, TestingModule } from '@nestjs/testing';
 
 import { ConfigModule } from '../../src';
 import { AppConfigService } from '../config/app-config.service';
+import { LogLevel } from '../config/log-level.enum';
+import { LoggerConfigService } from '../config/logger-config.service';
+import { PinoConfigService } from '../config/pino-config.service';
 import { RedisConfigService } from '../config/redis-config.service';
 
 describe('Multiple Config as Array', () => {
     let app: INestApplication;
     let appConfigService: AppConfigService;
     let redisConfigService: RedisConfigService;
+    let loggerConfigService: LoggerConfigService;
+    let pinoConfigService: PinoConfigService;
 
     beforeEach(async () => {
         process.env.REDIS_URL = 'IP:PORT';
 
         const moduleFixture: TestingModule = await Test.createTestingModule({
-            imports: [ConfigModule.forFeature([AppConfigService, RedisConfigService])],
+            imports: [ConfigModule.forFeature([AppConfigService, RedisConfigService, LoggerConfigService, PinoConfigService])],
         }).compile();
         app = moduleFixture.createNestApplication();
 
         appConfigService = moduleFixture.get<AppConfigService>(AppConfigService);
         redisConfigService = moduleFixture.get<RedisConfigService>(RedisConfigService);
+        loggerConfigService = moduleFixture.get<LoggerConfigService>(LoggerConfigService);
+        pinoConfigService = moduleFixture.get<PinoConfigService>(PinoConfigService);
 
         await app.init();
     });
@@ -33,5 +40,20 @@ describe('Multiple Config as Array', () => {
     it('should provide configuration', async () => {
         expect(appConfigService.env).toBe('test');
         expect(redisConfigService.url).toBe('IP:PORT');
+    });
+
+    describe('the cases with same variable name in different namespace', () => {
+        it('should not modify `process.env` object when the environment variable is undefined', async () => {
+            expect(loggerConfigService.logLevel).toBe(LogLevel.INFO);
+            expect(pinoConfigService.logLevel).toBe(LogLevel.DEBUG);
+            expect(process.env.LOG_LEVEL).toBeUndefined();
+        });
+
+        it('should not modify `process.env` object when the environment variable has value', async () => {
+            process.env.LOG_LEVEL = LogLevel.TRACE;
+            expect(loggerConfigService.logLevel).toBe(LogLevel.INFO);
+            expect(pinoConfigService.logLevel).toBe(LogLevel.DEBUG);
+            expect(process.env.LOG_LEVEL).toBe(LogLevel.TRACE);
+        });
     });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [x] CI related changes
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

purpose of added test case
- To have a better understanding of the behavior of the library.
- The fact that the library does not affect any change on `process.env` itself.
- To show same config name on different namespaces are not interfering with each other. This is why I add two config classes additionally even there are already 2 config services; `app-config` and `redis-config`.

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
