### PR TITLE
feat: config-scanner can parse default strings with newlines

### DIFF
--- a/spec/config-scanner/config-scanner.spec.ts
+++ b/spec/config-scanner/config-scanner.spec.ts
@@ -75,6 +75,12 @@ describe('ConfigScanner', () => {
                 groups: [ExampleConfigService.name],
                 conditions: ['IsString', 'IsOptional', 'IsEnum'],
             },
+            LONG_ARRAY_DEFAULT: {
+                conditions: ['IsString', 'IsOptional', 'IsEnum'],
+                defaultValue:
+                    'aaaaaaa,bbbbbbb,ccccccc,ddddddd,eeeeeee,fffffff,ggggggg,aaaaaaa,bbbbbbb,ccccccc,ddddddd,eeeeeee,fffffff,ggggggg,aaaaaaa,bbbbbbb,ccccccc,ddddddd,eeeeeee,fffffff,ggggggg',
+                groups: [ExampleConfigService.name],
+            },
         };
 
         expect(JSON.parse(jsonFile.toString())).toEqual(expected);

--- a/spec/config-scanner/example.config.service.ts
+++ b/spec/config-scanner/example.config.service.ts
@@ -31,4 +31,36 @@ export class ExampleConfigService extends AbstractConfigService<ExampleConfigSer
     @IsOptional()
     @IsEnum(LOG_LEVELS, { each: true })
     logLevels: LogLevel[];
+
+    @Expose({ name: 'LONG_ARRAY_DEFAULT' })
+    @Transform(
+        ({ value }) =>
+            value ?? [
+                'aaaaaaa',
+                'bbbbbbb',
+                'ccccccc',
+                'ddddddd',
+                'eeeeeee',
+                'fffffff',
+                'ggggggg',
+                'aaaaaaa',
+                'bbbbbbb',
+                'ccccccc',
+                'ddddddd',
+                'eeeeeee',
+                'fffffff',
+                'ggggggg',
+                'aaaaaaa',
+                'bbbbbbb',
+                'ccccccc',
+                'ddddddd',
+                'eeeeeee',
+                'fffffff',
+                'ggggggg',
+            ],
+    )
+    @IsString({ each: true })
+    @IsOptional()
+    @IsEnum(LOG_LEVELS, { each: true })
+    labels: string[];
 }

--- a/src/lib/config-scanner.ts
+++ b/src/lib/config-scanner.ts
@@ -301,9 +301,9 @@ export class ConfigScanner {
                     const body = (argumentNode as ts.ArrowFunction).body;
 
                     // case 1.
-                    if ((argumentNode as ts.ArrowFunction).body.kind === ts.SyntaxKind.BinaryExpression) {
-                        const binExpr = (argumentNode as ts.ArrowFunction).body as ts.BinaryExpression;
-                        defaultValue = binExpr.right.getText().replace(/'(.*)'$/, '$1');
+                    if (body.kind === ts.SyntaxKind.BinaryExpression) {
+                        const text = ((argumentNode as ts.ArrowFunction).body as ts.BinaryExpression).right.getText();
+                        defaultValue = text.includes('\n') ? this.convertValue<string>(text).toString() : text.replace(/'(.*)'$/, '$1');
                     } else if (body.kind !== ts.SyntaxKind.CallExpression) {
                         env.defaultValue = defaultValue;
                         break;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

If default value has line brakes inside, config-scanner generates docs keeping newline and spaces inside of the default value. it's hard to read. 

## What is the new behavior?

config-scanner removes formatting-purpose spaces and line breaks from default values while generating docs

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
