### PR TITLE
update parameter type of OptionalBoolean

### DIFF
--- a/src/lib/type-transformer/optional-boolean.spec.ts
+++ b/src/lib/type-transformer/optional-boolean.spec.ts
@@ -11,7 +11,7 @@ describe('OptionalBoolean', () => {
         expect(OptionalBoolean('false')).not.toBeTruthy();
     });
 
-    it('Should be returns same value if the strings are not `TRUE` and `FALSE`', () => {
+    it('Should return the same value if the result of `uppercase()` is neither `TRUE` nor `FALSE`', () => {
         for (const value of ['FAIL', 'tru', true, false, 1, 2, undefined, 'null', 'undefined', '']) {
             expect(OptionalBoolean(value)).toEqual(value);
         }

--- a/src/lib/type-transformer/optional-boolean.spec.ts
+++ b/src/lib/type-transformer/optional-boolean.spec.ts
@@ -12,7 +12,7 @@ describe('OptionalBoolean', () => {
     });
 
     it('Should be returns same value if the strings are not `TRUE` and `FALSE`', () => {
-        for (const value of ['FAIL', 'tru', true, false, 1, 2, undefined]) {
+        for (const value of ['FAIL', 'tru', true, false, 1, 2, undefined, 'null', 'undefined', '']) {
             expect(OptionalBoolean(value)).toEqual(value);
         }
     });

--- a/src/lib/type-transformer/optional-boolean.ts
+++ b/src/lib/type-transformer/optional-boolean.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export function OptionalBoolean(value: any) {
+export function OptionalBoolean(value: string | number | boolean | undefined) {
     switch (value?.toString().toUpperCase()) {
         case 'TRUE':
             return true;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The parameter type of `OptionalBoolean` is `any` for now, but expect that there is no use case that object will be passed to `OptionalBoolean`. So I added specific union type rather than use of any.

Issue Number: N/A

## What is the new behavior?

`OptionalBoolean` input parameter will have specific type constraint.


## Does this PR introduce a breaking change?

-   [x] Yes
-   [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
