### PR TITLE
fix: move typescript to dependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
         "lodash": "4.17.21",
         "reflect-metadata": "0.2.1",
         "rxjs": "7.8.1",
-        "tslib": "2.7.0"
+        "tslib": "2.7.0",
+        "typescript": "~5.5.2"
     },
     "devDependencies": {
         "@commitlint/config-conventional": "^19.0.3",
@@ -67,7 +68,6 @@
         "prettier": "^3.1.1",
         "release-it": "^17.0.1",
         "ts-jest": "29.2.5",
-        "ts-node": "10.9.2",
-        "typescript": "~5.5.2"
+        "ts-node": "10.9.2"
     }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, local variables)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When running NestJS application using @nestjs-library/config 0.4.4, it has following error.

```
node:internal/modules/cjs/loader:1228
  throw err;
  ^
Error: Cannot find module 'typescript'
Require stack:
- /woowa/app/node_modules/@nestjs-library/config/dist/lib/config-scanner.js
- /woowa/app/node_modules/@nestjs-library/config/dist/index.js
- /woowa/app/main.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1225:15)
    at Module._load (node:internal/modules/cjs/loader:1051:27)
    at Module.require (node:internal/modules/cjs/loader:1311:19)
    at require (node:internal/modules/helpers:179:18)
    at Object.<anonymous> (/woowa/app/node_modules/@nestjs-library/config/dist/lib/config-scanner.js:9:46)
    at Module._compile (node:internal/modules/cjs/loader:1469:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1548:10)
    at Module.load (node:internal/modules/cjs/loader:1288:32)
    at Module._load (node:internal/modules/cjs/loader:1104:12)
    at Module.require (node:internal/modules/cjs/loader:1311:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/woowa/app/node_modules/@nestjs-library/config/dist/lib/config-scanner.js',
    '/woowa/app/node_modules/@nestjs-library/config/dist/index.js',
    '/woowa/app/main.js'
  ]
}
Node.js v20.17.0
```

It is a same issue as [before](https://github.com/woowabros/nestjs-library-config/pull/143).

It seems like it has been changed [here](https://github.com/woowabros/nestjs-library-config/commit/2cc75b009b51fca6a529f56f5ca659058cd1baac#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R71).

## What is the new behavior?

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
